### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/formats.yml
+++ b/.github/workflows/formats.yml
@@ -2,6 +2,9 @@ name: Formats
 
 on: ['push', 'pull_request']
 
+permissions:
+  contents: read
+
 jobs:
   ci:
     runs-on: ${{ matrix.os }}


### PR DESCRIPTION
Potential fix for [https://github.com/deadjdona/pokio-up/security/code-scanning/2](https://github.com/deadjdona/pokio-up/security/code-scanning/2)

To fix the issue, we need to add a `permissions` block to the workflow. This block should specify the minimum permissions required for the workflow to function correctly. Based on the tasks performed in the workflow, the `contents: read` permission is sufficient, as the workflow only reads repository contents and does not perform any write operations.

The `permissions` block should be added at the root level of the workflow file to apply to all jobs. This ensures that the GITHUB_TOKEN used in the workflow has restricted permissions.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
