### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -2,6 +2,9 @@ name: Tests
 
 on: ['push', 'pull_request']
 
+permissions:
+  contents: read
+
 jobs:
   ci:
     runs-on: ${{ matrix.os }}


### PR DESCRIPTION
Potential fix for [https://github.com/deadjdona/pokio-up/security/code-scanning/1](https://github.com/deadjdona/pokio-up/security/code-scanning/1)

To fix the issue, we need to add a `permissions` block to the workflow file. Since the workflow performs basic CI tasks, the minimal required permission is `contents: read`. This ensures that the `GITHUB_TOKEN` has only the necessary access to read repository contents, avoiding any unnecessary write permissions.

The `permissions` block should be added at the root level of the workflow file, so it applies to all jobs in the workflow. No additional imports, methods, or definitions are required.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
